### PR TITLE
Add initial support for Markdown. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`tml` is a simple command-line tool that converts `.txt` files into `.html` format. The tool automatically wraps paragraphs from the input `.txt` file in `<p>...</p>` tags in the resulting `.html` file.
+`tml` is a simple command-line tool that converts `.txt` and `.md` files into `.html` format. The tool automatically wraps paragraphs from the input `.txt` or `.md` file in `<p>...</p>` or `h1, h2, h3` tags respectively in the resulting `.html` file.
 
 ## Installation
 
@@ -20,6 +20,9 @@ chmod +x main.py
 ```
 ## Usage
 
+By default, if no output directory is specified, the `.html` files will be saved inside the `tml/examples` directory.
+
+### Txt to HTML
 To convert a `.txt` file to `.html`:
 
 ```
@@ -31,20 +34,32 @@ To specify a different output directory:
 ```
 ./main.py <path-to-txt-file> --output <path-to-output-directory>
 ```
+### md to HTML
 
-By default, if no output directory is specified, the `.html` files will be saved inside the `tml/examples` directory.
+To convert a `.md` file to `.html`:
+
+```
+./main.py <path-to-md-file>
+```
+
+To specify a different output directory:
+
+```
+./main.py <path-to-md-file> --output <path-to-output-directory>
+```
 
 ## Command Options:
 | Options | Description |
 | --- | --- |
 | `--version` or `-v` | Display the tool's version. |
-| `path` | Specify the path to a `.txt` file or a directory containing multiple .txt files. If a directory is provided, `tml` will recursively process all `.txt` files within. |
+| `path` | Specify the path to a `.txt` or `.md` file or a directory containing multiple .txt files. If a directory is provided, `tml` will recursively process all `.txt` or `.md` files within. |
 | `--output` or `-o` | Specify a custom output directory. The tool will create the directory if it does not exist. |
 
 ## Features
 
-* 📄 Converts single or multiple `.txt` files to `.html`.
+* 📄 Converts single or multiple `.txt` and `.md` files to `.html`.
 * 🖋 Automatic paragraph wrapping in `<p>...</p>` tags.
+* 🖋 Automatic heading wrapping in h1, h2 ,h3 based on number of # specified in the `.md` file.
 * 📁 Can output to a custom directory or default to `tml/examples`.
 * 🔄 Overwrites existing output directory content to ensure it contains only the most recent outputs.
 * 🎉 Extracts title from the text file if present. The title is identified as the first line followed by two blank lines.

--- a/main.py
+++ b/main.py
@@ -78,6 +78,8 @@ def main():
             for file in files:
                 if file.endswith('.txt'):
                      create_html_from_txt(os.path.join(root, file), args.output)  # pass output directory here
+                elif file.endswith('.md'):
+                    pass
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -17,6 +17,9 @@ def process_file_content(content):
     html_paragraphs = [f"<p>{p.strip()}</p>" for p in body_paragraphs if p.strip()]
     return title, "\n".join(html_paragraphs)
 
+def create_html_from_md(filepath,output_dir='./tml/examples'):
+    print("md function called")
+    pass
    
 def create_html_from_txt(filepath, output_dir='./tml/examples'):
     with open(filepath, 'r') as f:
@@ -71,6 +74,8 @@ def main():
 
     if os.path.isfile(args.path) and args.path.endswith('.txt'):
         create_html_from_txt(args.path, args.output)
+    elif os.path.isfile(args.path) and args.path.endswith('.md'):
+        create_html_from_md(args.path, args.output)
     elif os.path.isdir(args.path):
         if os.path.exists(args.output):
             shutil.rmtree(args.output)
@@ -79,7 +84,7 @@ def main():
                 if file.endswith('.txt'):
                      create_html_from_txt(os.path.join(root, file), args.output)  # pass output directory here
                 elif file.endswith('.md'):
-                    pass
+                     create_html_from_md(os.path.join(root, file), args.output)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -17,9 +17,71 @@ def process_file_content(content):
     html_paragraphs = [f"<p>{p.strip()}</p>" for p in body_paragraphs if p.strip()]
     return title, "\n".join(html_paragraphs)
 
-def create_html_from_md(filepath,output_dir='./tml/examples'):
-    print("md function called")
-    pass
+def create_html_from_md(filepath, output_dir='./html/examples'):
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Read the Markdown content from the input file
+    with open(filepath, 'r', encoding='utf-8') as md_file:
+        markdown_content = md_file.read()
+
+    # Split the Markdown content into lines
+    lines = markdown_content.split('\n')
+
+    # Initialize an empty HTML content string
+    html_body_content = ""
+    current_paragraph=[]
+
+    for line in lines:
+        if line.startswith('# '):
+            # Close any open paragraph
+            if current_paragraph:
+                html_body_content += '<p>' + ' '.join(current_paragraph) + '</p>\n'
+                current_paragraph = []
+            # Add the heading
+            html_body_content += f'<h1>{line[2:]}</h1>\n'
+        elif line.startswith('## '):
+            if current_paragraph:
+                html_body_content += '<p>' + ' '.join(current_paragraph) + '</p>\n'
+                current_paragraph = []
+            html_body_content += f'<h2>{line[3:]}</h2>\n'
+        elif line.startswith('### '):
+            if current_paragraph:
+                html_body_content += '<p>' + ' '.join(current_paragraph) + '</p>\n'
+                current_paragraph = []
+            html_body_content += f'<h3>{line[4:]}</h3>\n'
+        elif line.strip():
+            # Append non-empty lines to the current paragraph
+            current_paragraph.append(line)
+        else:
+            # If it's an empty line, close the current paragraph (if any)
+            if current_paragraph:
+                html_body_content += '<p>' + ' '.join(current_paragraph) + '</p>\n'
+                current_paragraph = []
+
+    # Close any remaining open paragraph
+    if current_paragraph:
+        html_body_content += '<p>' + ' '.join(current_paragraph) + '</p>\n'
+
+    html_content = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Document</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"/>
+</head>
+<body>
+  {html_body_content}
+</body>
+</html>"""
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    output_file = os.path.join(output_dir, os.path.basename(filepath).replace('.md', '.html'))
+    with open(output_file, 'w') as f:
+        f.write(html_content)
+
    
 def create_html_from_txt(filepath, output_dir='./tml/examples'):
     with open(filepath, 'r') as f:


### PR DESCRIPTION
Hi,

The implementation for the changes specified in issue #7 has been completed. Kindly review the commits linked to this and let me know if any changes are required. 

Updates:
Readme updated regarding the new feature
updated the main function to check for .md extensions and pass to the new function created.
The new function handles replacing #,##,### with h1,h2,h3 and parses paragraphs with a similar logic of consecutive lines being in the same paragraph.

Thank you.