### PR TITLE
added support for flags input using toml config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # created by virtualenv automatically
-*
+
 __pycache__/
 *.pyc
 *.pyo

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To specify a different output directory:
 | `--version` or `-v` | Display the tool's version. |
 | `path` | Specify the path to a `.txt` or `.md` file or a directory containing multiple .txt files. If a directory is provided, `tml` will recursively process all `.txt` or `.md` files within. |
 | `--output` or `-o` | Specify a custom output directory. The tool will create the directory if it does not exist. |
+| `--config` or `-c` | Specify a custom `TOML` based config file where all the above flags and their values can be passed instead of passing them through command line input which are ignored if passed along with this flag.  |
 
 ## Features
 

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,4 @@
+path = "./examples"
+output = "./build"
+lang = "fr"
+version = false

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import shutil
 import re
+import tomli
 
 def process_file_content(content):
     lines = content.split("\n")
@@ -120,13 +121,44 @@ def main():
     parser.add_argument('--version', '-v', action='store_true', help='print the tool\'s name and version')
     parser.add_argument('--output', '-o', default='./tml/examples', help='Specify a different output directory')
     parser.add_argument('--lang', '-l', default='en-CA', help='Specify the language for the lang attribute in the HTML document')
+    parser.add_argument('--config', '-c', help='Specify a different config file')
 
  
 
     args = parser.parse_args()
 
+
+    if args.config:
+        try:
+            with open(args.config, "rb") as f:
+                default_values = {
+                    'path': None,
+                    'output': './tml/examples',
+                    'lang': 'en-CA',
+                    'version': False
+                }
+                
+                toml_dict = tomli.load(f)
+                
+                # Convert the dict to a Namespace object 
+                args = argparse.Namespace(**toml_dict)
+
+                # Set any missing args to their default values
+                for key, value in default_values.items():
+                    setattr(args, key, getattr(args, key, value))
+        except tomli.TOMLDecodeError:
+            print(f"Error: {args.config} is not a valid config TOML file.")
+            return(-1)
+        except FileNotFoundError:
+            print(f"Error: {args.config} does not exist.")
+            return(-1)
+        except IsADirectoryError:
+            print(f"Error: {args.config} is a directory. Must provide path to config file.")
+            return(-1)
+
+
     if args.version:
-        print("tml Tool Version 0.0.2")
+        print("tml Tool Version 0.0.3")
         return(0)
 
     if not args.path:
@@ -147,9 +179,9 @@ def main():
         for root, dirs, files in os.walk(args.path):
             for file in files:
                 if file.endswith('.txt'):
-                     create_html_from_txt(os.path.join(root, file), args.output)  # pass output directory here
+                     create_html_from_txt(os.path.join(root, file), args.lang, args.output)  # pass output directory here
                 elif file.endswith('.md'):
-                     create_html_from_md(os.path.join(root, file), args.output)
+                     create_html_from_md(os.path.join(root, file), args.lang, args.output)
 
  except Exception as e:
     print(f"An unexpected error occurred: {e}")


### PR DESCRIPTION
* Fixes issue #13 

I've added full support for parsing the flags through the TOML config file. I used a py lib called `tomli` to parse the TOML file. It handles reading and parsing the file. Besides, it also takes care of the invalidity of the TOML file through the use of exceptions. The PR also makes use of existing code that was written for cmd line args where it already checks whether a path or a directory is valid or whether a file is a txt or md file among other requirements. The purpose was to reuse the code as much as possible so I'm also converting the dictionary that `tomli` builds to a Namespace class object since `argparse` library converts the cmd line args to a Namespace class' object. This helps me reuse the existing logic which checks for the validity of the flags. Documentation has also been updated accordingly.

Features addressed with this PR:
1. The `-c` or `--config` flags accept a file path to a TOML-based config file.
2. If the file is missing, or can't be parsed as TOML, the program exits with an appropriate error message.
3. If the `-c` or `--config` option is provided, the program ignores all other options (i.e., a config file overrides other options on the command line).
4. The program ignores any options in the config file it doesn't recognize. For example, if the app doesn't support stylesheets, it ignores a stylesheet property.
5. If the config file is missing any options, it assumes the usual defaults.