### PR TITLE
added 2 tests for markdown replace_links function

### DIFF
--- a/tests/test_markdown_link_replacer.py
+++ b/tests/test_markdown_link_replacer.py
@@ -16,3 +16,19 @@ def test_replace_links_good():
     assert (
         output == expected_output
     ), "replace_links did not return expected HTML content"
+
+# Test replace_links with a broken link in markdown content
+def test_replace_links_broken_link_markdown():
+    input_data = "Test content with a [broken link](http://example.com/broken)"
+    expected_output = 'Test content with a <a href="#" style="color:red;">broken link</a>'
+    output, broken_links = replace_links("test.md", input_data, True)
+    assert output == expected_output
+    assert broken_links == ["http://example.com/broken"]
+
+# Test replace_links with valid link in plain text content
+def test_replace_links_valid_link_plain_text():
+    input_data = "This is a valid link: http://www.valid-link.com"
+    expected_output = 'This is a valid link: <a href="http://www.valid-link.com">http://www.valid-link.com</a>'
+    output, broken_links = replace_links("test.txt", input_data, False)
+    assert output == expected_output
+    assert broken_links == []


### PR DESCRIPTION
**Pull Request Description:**

### Summary

This pull request adds two test cases to further validate the functionality of the `replace_links` function. The new tests cover scenarios involving broken links in Markdown content and valid links in plain text content.

### Changes Made

1. **Test replace_links with a broken link in markdown content:**
   - Input: "Test content with a [broken link](http://example.com/broken)"
   - Expected Output: 'Test content with a <a href="#" style="color:red;">broken link</a>'
   - Assertion: Ensure the function correctly handles and identifies broken links in Markdown content.

2. **Test replace_links with valid link in plain text content:**
   - Input: "This is a valid link: http://www.valid-link.com"
   - Expected Output: 'This is a valid link: <a href="http://www.valid-link.com">http://www.valid-link.com</a>'
   - Assertion: Confirm that the function accurately converts valid links in plain text content to HTML anchor tags.

### Additional Information

These tests enhance the test coverage for the `replace_links` function, addressing specific scenarios related to broken links in Markdown and valid links in plain text. The existing test suite is expanded to ensure comprehensive testing of the function's capabilities.

This change is intended to improve the overall robustness of the codebase and validate the correctness of the link replacement logic in various contexts.

### Checklist

- [x] All tests pass successfully.
- [x] Code is formatted and adheres to the project's coding standards.
- [x] Documentation, if applicable, is updated to reflect the changes.
